### PR TITLE
fix bug that inter-state import of same symbol is possible but causes error.

### DIFF
--- a/ffiex-0.2.0-7.rockspec
+++ b/ffiex-0.2.0-7.rockspec
@@ -1,5 +1,5 @@
 package = "ffiex"
-version = "0.2.0-6"
+version = "0.2.0-7"
 source = {
   url = "git://github.com/umegaya/ffiex.git",
 }

--- a/test/import.lua
+++ b/test/import.lua
@@ -1,4 +1,6 @@
 local ffi = require 'ffiex.init'
+--ffi.__DEBUG_CDEF__ = true
+
 ffi.import({
 "printf",
 "sprintf",

--- a/test/import3.lua
+++ b/test/import3.lua
@@ -1,0 +1,31 @@
+local ffi = require 'ffiex.init'
+-- ffi.__DEBUG_CDEF__ = true
+
+local s1, s2 = ffi.newstate(), ffi.newstate()
+
+s1:copt { cc = "gcc" }
+s2:copt { cc = "gcc" }
+
+s1:import({"nanosleep"}):from [[
+	#include <time.h>
+]]
+assert(ffi.imported_csymbols["timespec"], "timespec not imported")
+if ffi.os == "OSX" then
+	s2:import({"kevent"}):from [[
+		#include <sys/types.h>
+		#include <sys/time.h>
+		#include <sys/event.h>
+	]]
+
+assert(ffi.C.nanosleep)
+assert(ffi.C.kevent)
+elseif ffi.os == "Linux" then
+	s2:import({"clock_gettime"}):from [[
+		#include <time.h>
+	]]
+assert(ffi.C.nanosleep)
+local rt = ffi.load("rt")
+assert(rt.clock_gettime)
+end
+
+return true

--- a/test/pdcurses.lua
+++ b/test/pdcurses.lua
@@ -1,6 +1,8 @@
 local ffi = require 'ffiex.init'
 
 local state = ffi.newstate()
+-- ffi need to configure for loading tcc header and lib
+ffi.path "./test/myheaders/tcc"
 state:copt { cc = "tcc" }
 state:cdef [[
 //complement missing definition

--- a/test/state.lua
+++ b/test/state.lua
@@ -15,6 +15,9 @@ assert(nil == ffi.defs.FOO, "FOO should not exist:"..tostring(ffi.defs.FOO))
 -- able to define another macro FOO
 local src_fdecl = state:src_of("no_return_fn")
 assert(src_fdecl:gsub("%s", "") == fdecl:gsub("%s", ""), "invalid src_of:["..src_fdecl.."]")
+local src_fdecl2 = state:src_of("no_return_fn", true)
+assert(src_fdecl2:gsub("%s", "") == fdecl:gsub("%s", ""), "invalid src_of:["..src_fdecl2.."]")
+
 ffi.cdef[[
 #define FOO(x) (x + 10)
 ]]


### PR DESCRIPTION
``` lua
local s1, s2 = ffi.newstate(), ffi.newstate()

s1:copt { cc = "gcc" }
s2:copt { cc = "gcc" }

s1:import({"nanosleep"}):from [[
    #include <sys/types.h>
    #include <sys/time.h>
]]
s2:import({"kevent"}):from [[
    #include <sys/types.h>
    #include <sys/time.h>
    #include <sys/event.h>
]] --[[ causes error attempt to redefine 'timespec' at line 25, 
because previous ffiex cannot check the attempt to import same symbol over 2 state. 
its basically blocked for same state, because of C style include guard.]]
```
