### PR TITLE
always use inject even not using import

### DIFF
--- a/ffiex/parser.lua
+++ b/ffiex/parser.lua
@@ -32,32 +32,22 @@ local function make_sym_dep(sym, name, deps, cdef)
 	end
 	local cdef = cdef:gsub("^%s+", ""):gsub("%s+$", "")
 	if sym[name] then
-		if sym[name].temp then
-			local prev_cdef = sym[name].cdef
-			if prev_cdef:gsub('%s', ''):gsub('__asm__%s*%b()', '') ~= 
-				cdef:gsub('%s', ''):gsub('__asm__%s*%b()', '') then
-				-- struct/union/enum hoge hoge; => struct/union/enum hoge {...} is valid.
-				if #prev_cdef <= 0 or prev_cdef:find('^typedef%s+[_%w]+%s+'..name.."%s+"..name) then
-					log(name..' ok: ['..sym[name].cdef..']=>['..cdef..']')
-				elseif prev_cdef:find('^struct+%s+[_%w]') then
-					log(name..' ok: ['..sym[name].cdef..']=>['..cdef..']')
-				else
-					print(name..' conflict: ['..sym[name].cdef..']=>['..cdef..']')
-				end
-			end
-		else
-			log('caution:'..name.." already exist:"..debug.traceback())
-		end
+		log('caution:'..name.." already exist:"..debug.traceback())
 	end
+	table.insert(sym[1], name)
 	sym[name] = {
 		name = name,
 		deps = deps,
 		cdef = cdef,
+		prio = #(sym[1]),
 	}
 end
 
+local function get_real_sym_name(pfx, name)
+	return pfx.." "..name
+end
 local function get_func_sym_name(name)
-	return "func "..name
+	return get_real_sym_name("func", name)
 end
 local function make_func_dep(sym, name, deps, cdef)
 	make_sym_dep(sym, get_func_sym_name(name), deps, cdef)
@@ -68,10 +58,12 @@ local function make_incomplete_decl(sym, name, cdef)
 		log(name .. " already declared as:["..sym[name].cdef.."]")
 		return
 	end
+	table.insert(sym[1], name)
 	sym[name] = {
 		name = name,
 		cdef = cdef,
 		temp = true,
+		prio = #(sym[1]),
 	}
 end
 
@@ -80,7 +72,7 @@ local function has_sym(sym, name)
 end
 
 local function new_sym_table()
-	local sym = {}
+	local sym = {[1] = {}}
 	make_sym_dep(sym, "void", nil, "")
 
 	make_sym_dep(sym, "_Bool", nil, "")
@@ -111,6 +103,7 @@ local function new_sym_table()
 	make_sym_dep(sym, "float", nil, "")
 
 	make_sym_dep(sym, "__builtin_va_list", nil, "")
+
 	return sym
 end
 
@@ -315,10 +308,19 @@ local function common_parse_qualifier(sym, src, ext_attr_list)
 			base_type = kw.." "..(base_type or "int")
 		end
 	end
+
 	-- otherwise symbol is actually typename.
 	vlog('ret:', base_type or symbol, attr, varname)
 	if base_type then
 		symbol = base_type
+	else
+		for _,kw in ipairs({"struct", "union", "enum"}) do
+			if attr[kw] then
+				log("attr has kw:"..kw)
+				symbol = kw.." "..symbol
+				break
+			end
+		end
 	end
 	if not has_sym(sym, symbol) then
 		make_incomplete_decl(sym, symbol, src)
@@ -379,7 +381,7 @@ local function parse_var_decl_var(sym, opaque, deps, matches, src)
 end
 
 -- (*var[size])(...)
-local VAR_DECL_VAR_FUNC="^".."%(?"..
+local VAR_DECL_VAR_FUNC="^"..OPT_SPACE_OR_STAR.."%(?"..
 	VAR_DECL_CAPTURE..OPTSPACE.."%)?"..OPTSPACE..
 	"("..ARG_VAR_LIST..")"..OPTSPACE
 local function parse_var_decl_var_func(sym, opaque, deps, matches, src)
@@ -390,7 +392,7 @@ local function parse_var_decl_var_func(sym, opaque, deps, matches, src)
 end
 
 -- (*(*var[size])(...))(...)
-local VAR_DECL_VAR_HO_FUNC="^".."%(?"..
+local VAR_DECL_VAR_HO_FUNC="^"..OPT_SPACE_OR_STAR.."%(?"..
 	VAR_DECL_CAPTURE..OPTSPACE..
 	"("..ARG_VAR_LIST..")"..OPTSPACE.."%)?"..OPTSPACE..
 	"("..ARG_VAR_LIST..")"..OPTSPACE
@@ -421,6 +423,7 @@ local function parse_typedef(sym, opaque, deps, matches, src)
 	end
 	for _,typedecl in ipairs(typedecls) do
 		local depends = depslist[typedecl]
+		-- predecl is not counted as dependency (because no actual declaration required)
 		if depends then
 			table.insert(depends, typename)
 		else
@@ -445,7 +448,7 @@ local STRUCTURE_TYPEDEF="^"..TYPEDEF_SYMBOL..SPACE..
 	"("..ALL_REMAINS..")"..";"
 local function parse_structure_typedef(sym, opaque, deps, matches, src)
 	src = restore_src(src, opaque)
-	local typename = matches[2]
+	local typename = get_real_sym_name(matches[1], matches[2])
 	local vardeps = {}
 	if matches[1] == "enum" then
 		make_sym_dep(sym, typename, {}, src)
@@ -533,10 +536,10 @@ end
 local STRUCTURE_DECL="^"..
 	"("..STRUCTURE_SYMBOL..")"..SPACE..
 	"("..TYPENAME..")"..OPTSPACE..
-	"("..STRUCT_VAR_LIST..")"..OPTSPACE..";"
+	"("..STRUCT_VAR_LIST..")"..OPT_QUALIFIER..";"
 local function parse_structure_decl(sym, opaque, deps, matches, src)
 	src = restore_src(src, opaque)
-	local typename, vardeps = matches[2], {}
+	local typename, vardeps = get_real_sym_name(matches[1], matches[2]), {}
 	common_parse_struct_deps(sym, vardeps, matches[3], typename)
 	make_sym_dep(sym, typename, vardeps, src)
 end
@@ -558,7 +561,7 @@ local STRUCTURE_PREDECL="^"..
 	"("..TYPENAME..")"..OPTSPACE..";"
 local function parse_structure_predecl(sym, opaque, deps, matches, src)
 	src = restore_src(src, opaque)
-	local typename = matches[2]
+	local typename = get_real_sym_name(matches[1], matches[2])
 	make_incomplete_decl(sym, typename, src)
 end
 
@@ -633,7 +636,7 @@ local STRUCT_VAR_STRUCT="^"..
 	"("..ALL_REMAINS..")"
 local function parse_struct_var_struct(sym, opaque, deps, matches, src)
 	local vardeps = {}
-	local typename = matches[2]
+	local typename = get_real_sym_name(matches[1], matches[2])
 	common_parse_struct_deps(sym, vardeps, matches[3], opaque)
 	-- currently, struct declaration in struct cannot be injected (empty string returns)
 	make_sym_dep(sym, typename, vardeps, "")
@@ -789,9 +792,6 @@ local function traverse_cdef(tree, symbol, injected, depth)
 		if not injected.lookup[dep] then
 			if not injected.seen[dep] then
 				injected.seen[dep] = true
-				if depth > 1000 then
-					error('stack depth too deep:'..symbol)
-				end
 				traverse_cdef(tree, dep, injected, depth + 1)
 			end
 		end
@@ -812,10 +812,15 @@ local function get_name_in_sym(tree, symbol)
 	local s, e = symbol:find('%s+')
 	if s then
 		local pfx = symbol:sub(1, s - 1)
-		return pfx == "func" and symbol or symbol:sub(e+1)
+		return pfx == "typename" and symbol:sub(e+1) or symbol
 	else
-		local fsym = get_func_sym_name(symbol)
-		return tree[fsym] and fsym or symbol
+		for _,pfx in ipairs({"struct", "func", "union", "enum"}) do
+			local fsym = get_real_sym_name(pfx, symbol)
+			if tree[fsym] then
+				return fsym
+			end
+		end
+		return symbol
 	end
 end
 
@@ -826,18 +831,24 @@ local function inject(tree, symbols, already_imported)
 		seen = {},
 		chunks = {},
 	}
-	if symbols then
+	if type(symbols) == 'table' then
 		for _,symbol in ipairs(symbols) do
-			traverse_cdef(tree, get_name_in_sym(tree, symbol), injected, 0)
+			if not injected.lookup[symbol] then
+				traverse_cdef(tree, get_name_in_sym(tree, symbol), injected, 0)
+			end
 		end
 	else
-		for k,v in pairs(tree) do
-			traverse_cdef(tree, k, injected, 0)
+		for _,k in pairs(tree[1]) do
+			if not injected.lookup[k] then
+				-- print('inject:'..k..'['..tree[k].cdef..']')
+				traverse_cdef(tree, k, injected, 0)
+			end
 		end
 	end
 	local cdef = ""
+	table.sort(injected.list, function (e1, e2) return e1.prio < e2.prio end)
 	for _,sym in ipairs(injected.list) do
-		log("sym injected:["..sym.name.."]")
+		log("sym injected:["..sym.name.."]["..sym.cdef.."]")
 		assert(sym.cdef, "invalid sym no cdef:"..sym.name)
 		cdef = (cdef .. "\n" .. (sym.cdef or ""))
 	end

--- a/test/import3.lua
+++ b/test/import3.lua
@@ -9,9 +9,9 @@ s2:copt { cc = "gcc" }
 s1:import({"nanosleep"}):from [[
 	#include <time.h>
 ]]
-assert(ffi.imported_csymbols["timespec"], "timespec not imported")
+assert(ffi.imported_csymbols["struct timespec"], "timespec not imported")
 if ffi.os == "OSX" then
-	s2:import({"kevent"}):from [[
+	s2:import({"func kevent"}):from [[
 		#include <sys/types.h>
 		#include <sys/time.h>
 		#include <sys/event.h>
@@ -27,5 +27,11 @@ assert(ffi.C.nanosleep)
 local rt = ffi.load("rt")
 assert(rt.clock_gettime)
 end
+
+ffi.cdef [[
+#include <time.h>
+]]
+
+assert(ffi.C.time)
 
 return true

--- a/test/parser.lua
+++ b/test/parser.lua
@@ -1,6 +1,7 @@
 local parser = require 'ffiex.parser'
 
 local function check_dependency(sym, typename, deps, cdef_checker)
+	typename = parser.name(sym, typename)
 	local t = assert(sym[typename], typename .. " not exist")
 	for i,d in ipairs(deps) do
 		local found
@@ -27,7 +28,8 @@ check_dependency(sym, "test1_a_t", {"unsigned int"})
 check_dependency(sym, "test1_b_t", {"unsigned int"})
 check_dependency(sym, "test1_c_t", {"unsigned long long int"})
 check_dependency(sym, "test1_d_t", {"unsigned long long int"})
-check_dependency(sym, "test1_e_t", {"int"})
+check_dependency(sym, "struct test1_e_t", {"int"})
+check_dependency(sym, "typename test1_e_t", {"struct test1_e_t"})
 check_dependency(sym, "integer_t", {"int"})
 
 
@@ -45,8 +47,8 @@ sym = parser.parse(nil, [[
  } test2_b_t;
 ]])
 check_dependency(sym, "_test2_a_t", {"long int", "void", "char"})
-check_dependency(sym, "test2_a_t", {"_test2_a_t"})
-check_dependency(sym, "test2_b_t", {"_test2_b_t"})
+check_dependency(sym, "test2_a_t", {"struct _test2_a_t"})
+check_dependency(sym, "test2_b_t", {"enum _test2_b_t"})
 
 
 -- test3
@@ -93,8 +95,8 @@ check_dependency(sym, "func test5_b_fn", {"int", "char", "short int", "void", "u
 	return cdef:find("__asm%(hoge%)")
 end)
 check_dependency(sym, "_test5_a_t", {"void"})
-check_dependency(sym, "test5_a_t", {"_test5_a_t"})
-check_dependency(sym, "func test5_c_fn", {"_test5_a_t", "test5_a_t"})
+check_dependency(sym, "test5_a_t", {"struct _test5_a_t"})
+check_dependency(sym, "func test5_c_fn", {"struct _test5_a_t", "test5_a_t"})
 check_dependency(sym, "func test5_d_fn", {"void", "int"}, function (cdef)
 	return cdef:find('__declspec%(dllimport%)')
 end)
@@ -121,7 +123,7 @@ typedef struct {
 ]])
 check_dependency(sym, "test6_a_t", {"void", "int"})
 check_dependency(sym, "test6_b_t", {"test6_a_t"})
-check_dependency(sym, "test6_c_t", {"test6_a_t", "test6_b_t", "int", "char", "long int", "test6_d_t"})
+check_dependency(sym, "test6_c_t", {"test6_a_t", "test6_b_t", "int", "char", "long int", "struct test6_d_t"})
 check_dependency(sym, "test6_d_t", {})
 
 return true


### PR DESCRIPTION
previoulsly if entire header file is specified to cdef by #include, we pass preprocessed included file output to ffi.cdef.

to check import dependency more correctly, ffiex now using inject method for every cdef so that ffiex knows all dependency and which declaration need to import now (to avoid duplicated declaration more correctly).

I will provide fast mode (not parse dependency mode, all import just pass preprocessed output to ffi.cdef) for faster processing. (not now)
