### PR TITLE
Umegaya/fix/functional macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/*.h
 .DS_Store
 a.out
 *.c
+tmp.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+ffiex/cache/*
 tmp/*.h
 **/.DS_Store
 .DS_Store

--- a/ffiex/init.lua
+++ b/ffiex/init.lua
@@ -8,7 +8,7 @@ local originalCompileFile = lcpp.compileFile
 local lastTryPath
 local currentState
 
-local function search_header_file(filename, predefines, nxt, _local)
+local function search_header_file(filename, predefines, nxt, _local, no_throw)
 	lastTryPath = lastTryPath or predefines.__FILE__:gsub('^(.*/)[^/]+$', '%1')
 	if nxt then
 		local process
@@ -49,17 +49,23 @@ local function search_header_file(filename, predefines, nxt, _local)
 		end
 	end
 	--> OMG header not found...
-	local paths = ""
-	for _,path in ipairs(currentState.searchPath) do
-		paths = paths .. "\n" .. path
+	if not no_throw then
+		local paths = ""
+		for _,path in ipairs(currentState.searchPath) do
+			paths = paths .. "\n" .. path
+		end
+		error(filename .. ' not found in:' .. paths .. "\n at \n" .. debug.traceback())
 	end
-	error(filename .. ' not found in:' .. paths .. "\n at \n" .. debug.traceback())
 	return nil
 end
 
 lcpp.compileFile = function (filename, predefines, macro_sources, nxt, _local)
 	filename, lastTryPath = search_header_file(filename, predefines, nxt, _local)
-	--> print('include:'..filename)	
+	if ffi.__DEBUG_CDEF__ then
+		local out = {originalCompileFile(filename, predefines, macro_sources, nxt)}
+ print('include:'..filename)--.."=>"..out[1])
+ 		return unpack(out)
+ 	end
 	return originalCompileFile(filename, predefines, macro_sources, nxt)
 end
 
@@ -70,7 +76,13 @@ local header_name = "__has_include_next%(%s*[\"<]+(.*)[\">]+%s*%)"
 local function has_include_next(decl)
 	local file = decl:match(header_name)
 	-- print("has_include_next:", file, decl)
-	return search_header_file(file, currentState.lcpp_defs, true, false) ~= nil and "1" or "0"
+	return search_header_file(file, currentState.lcpp_defs, true, false, true) ~= nil and "1" or "0"
+end
+local header_name2 = "__has_include%(%s*[\"<]+(.*)[\">]+%s*%)"
+local function has_include(decl)
+	local file = decl:match(header_name2)
+	-- print("has_include_next:", file, decl)
+	return search_header_file(file, currentState.lcpp_defs, false, false, true) ~= nil and "1" or "0"
 end
 local function __asm(exp)
 	return exp:gsub("__asm_*%s*%b()", "")
@@ -224,6 +236,7 @@ function ffi_state:init(try_init_path)
 
 	-- add built in macro here
 	self.lcpp_defs = {
+		["__has_include"] = has_include, 
 		["__has_include_next"] = has_include_next, 
 		-- i don't know the reason but OSX __asm alias not works for luajit symbol search
 		["__asm"] = __asm, -- just return empty string TODO : investigate reason.
@@ -265,6 +278,8 @@ function ffi_state:parse(decl, tmptree)
 	end
 	currentState = self
 	local output, state = lcpp.compile(decl, self.lcpp_defs, self.lcpp_macro_sources)
+	--print('output='..output)
+	local has_ssize_t = output:match('ssize_t;')
 	self.lcpp_defs = state.defines
 	self.lcpp_macro_sources = state.macro_sources
 	if tmptree and self.tree then

--- a/ffiex/init.lua
+++ b/ffiex/init.lua
@@ -532,5 +532,8 @@ end
 function ffi.newstate()
 	return ffi_state.new()
 end
+function ffi.init_cdef_cache()
+	utils.create_builtin_config_cache()
+end
 
 return ffi

--- a/ffiex/lcpp.lua
+++ b/ffiex/lcpp.lua
@@ -566,7 +566,8 @@ local function apply(state, input)
 			-- print('tokenize:'..tostring(k).."["..tostring(v).."]")
 			if k == "identifier" then 
 				local repl = v
-				local macro = state.defines[v] 
+				local macro = state.defines[v]
+				-- print(tostring(state.defines)..' tokenize:'..tostring(v).."=>"..tostring(macro))
 				if macro then
 					if type(macro)     == "boolean" then
 						repl = ""
@@ -794,7 +795,7 @@ end
 
 -- sets a global define
 local function define(state, key, value, override, macro_source)
-	--print("define:"..key.." type:"..tostring(value).." value:"..tostring(pval))
+	-- print(tostring(state.defines).." define:"..key.." value:"..tostring(value).." src:"..tostring(state.macro_sources[key]))
 	if value and not override then
 		if type(value) == 'function' then
 			assert(macro_source, "macro source should specify to check identity")
@@ -1109,7 +1110,7 @@ local function parseExpr(state, input)
 	end
 	
 	for type, value in input do
-		-- print("type:"..type.." value:"..value)
+	-- print("type:"..type.." value:"..value)
 		-- unary operator
 		if type == "NOT" or 
 			type == "BNOT" then

--- a/ffiex/util.lua
+++ b/ffiex/util.lua
@@ -1,9 +1,41 @@
 local _M = {}
 local ffi = require 'ffi'
 
+function _M.get_gcc_version()
+	return io.popen('gcc -v'):read('*a')
+end
+function _M.file_exists(file)
+	if ffi.os ~= 'Windows' then
+		return io.popen([[if [ -e '%s' ]; then echo '1'; else echo '0'; fi]]):read('*a') == '1'
+	else
+		error('unsupported OS')
+	end
+end
+function _M.current_path()
+	local data = debug.getinfo(1)
+	return data.source:match('@(.+)/.+$')
+end
+local builtin_paths = (_M.current_path()..'/cache/builtin_paths')
+local builtin_defs = (_M.current_path()..'/cache/builtin_defs')
+
 -- add compiler predefinition
+local builtin_defs_cmd = 'echo | gcc -E -dM -'
+local function create_builtin_defs_cache()
+	os.execute('echo "'..v..'">'..builtin_defs..".version")
+	os.execute(builtin_defs_cmd..'>>'..builtin_defs)
+end
+local function get_builtin_defs()
+	if _M.file_exists(builtin_defs) then
+		local v = _M.get_gcc_version()
+		if v ~= io.popen(('cat %s'):format(builtin_defs..".version")):read('*a') then
+			create_builtin_defs_cache()
+		end
+		return io.popen(([[cat %s]]):format(builtin_defs))
+	end
+	return io.popen(builtin_defs_cmd)
+end
 function _M.add_builtin_defs(state)
-	local p = io.popen('echo | gcc -E -dM -')
+	local p = get_builtin_defs()
 	local predefs = p:read('*a')
 	state:cdef(predefs)
 	p:close()
@@ -15,7 +47,7 @@ function _M.add_builtin_defs(state)
 	end
 end
 function _M.clear_builtin_defs(state)
-	local p = io.popen('echo | gcc -E -dM -')
+	local p = io.popen(builtin_defs_cmd)
 	local undefs = {}
 	while true do 
 		local line = p:read('*l')
@@ -33,8 +65,25 @@ function _M.clear_builtin_defs(state)
 end
 
 -- add compiler built in header search path
+local builtin_paths_cmd = 'echo | gcc -xc -v - 2>&1 | cat'
+function _M.create_builtin_paths_cache()
+	local path = _M.current_path()
+	local v = _M.get_gcc_version()
+	os.execute('echo "'..v..'">'..builtin_paths..".version")
+	os.execute(builtin_paths_cmd..'>>'..builtin_paths)
+end
+local function get_builtin_paths()
+	if _M.file_exists(builtin_paths) then
+		local v = _M.get_gcc_version()
+		if v ~= io.popen(('cat %s'):format(builtin_paths..".version")):read('*a') then
+			create_builtin_paths_cache()
+		end
+		return io.popen(([[cat %s]]):format(builtin_paths))
+	end
+	return io.popen(builtin_paths_cmd)
+end
 function _M.add_builtin_paths(state)
-	local p = io.popen('echo | gcc -xc -v - 2>&1 | cat')	
+	local p = get_builtin_paths()
 	local search_path_start
 	while true do
 		-- TODO : parsing unstructured compiler output.
@@ -42,6 +91,7 @@ function _M.add_builtin_paths(state)
 		-- but I cannot find better way than this.
 		local line = p:read('*l')
 		if not line then break end
+		-- print('line = ', line)
 		if search_path_start then
 			local tmp,cnt = line:gsub('^%s+(.*)', '%1')
 			if cnt > 0 then
@@ -56,6 +106,10 @@ function _M.add_builtin_paths(state)
 			search_path_start = true
 		end
 	end
+end
+function _M.create_builtin_config_cache()
+	create_builtin_paths_cache()
+	create_builtin_defs_cache()
 end
 
 return _M

--- a/test/cache.lua
+++ b/test/cache.lua
@@ -1,0 +1,12 @@
+local ffi = require 'ffiex.init'
+local util = require 'ffiex.util'
+
+ffi.init_cdef_cache()
+local v, d, p = io.open(util.path.version_file):read('*a'),
+	io.open(util.path.builtin_defs):read('*a'),
+	io.open(util.path.builtin_paths):read('*a')
+ffi.clear_cdef_cache()
+assert(v == util.gcc_version())
+assert(d == util.builtin_defs():read('*a'))
+
+return true

--- a/test/ffiex.lua
+++ b/test/ffiex.lua
@@ -1,4 +1,5 @@
 local ffi = require 'ffiex.init'
+ffi.__DEBUG_CDEF__ = true
 
 local pt
 if ffi.os == 'OSX' then

--- a/test/ffiex.lua
+++ b/test/ffiex.lua
@@ -1,5 +1,5 @@
 local ffi = require 'ffiex.init'
-ffi.__DEBUG_CDEF__ = true
+-- ffi.__DEBUG_CDEF__ = true
 
 local pt
 if ffi.os == 'OSX' then

--- a/test/lcpp.lua
+++ b/test/lcpp.lua
@@ -1,3 +1,13 @@
 local lcpp = require 'ffiex.lcpp'
+-- unit test
 lcpp.test()
+-- other pathological tests
+lcpp.compile([[
+#ifndef HOGE
+struct var {
+    void (*__routine)(void *);      // Routine to call
+    void *__arg;                    // Argument to pass
+    struct __darwin_pthread_handler_rec *__next;
+};
+#endif // HOGE]])
 return true

--- a/test/parseheaders.lua
+++ b/test/parseheaders.lua
@@ -3,7 +3,6 @@ function try_parse_headers(directory)
     local ffi = require "ffiex.init"
     local blacklist
     if ffi.os == "OSX" then
-    	ffi.cdef "#define XP_NO_X_HEADERS"
         blacklist = {
             "cxxabi.h", -- namespace is contained
             "nc_tparm.h", -- TPARM_1 declared twice

--- a/test/parser.lua_
+++ b/test/parser.lua_
@@ -1,4 +1,5 @@
 local ffi = require "ffiex.init"
+-- ffi.__DEBUG_CDEF__ = true
 local required
 local expath 
 if ffi.os == "OSX" then
@@ -13,6 +14,7 @@ if ffi.os == "OSX" then
 		["tkDecls.h"] = {"tcl.h"}, -- EXTERN, CONST84_RETURN
 		["lber.h"] = {"lber_types.h"},
 		["ldif.h"] = {"lber_types.h"},
+		["reboot2.h"] = {"sys/types.h"}, -- ssize_t
 		["sys/_select.h"] = {"sys/_types/_fd_def.h"},
 		["sys/acct.h"] = {"i386/types.h", "sys/_types/_uid_t.h", "sys/_types/_gid_t.h", "sys/_types/_dev_t.h"},
 		["sys/acl.h"] = {"i386/types.h", "sys/_types/_uid_t.h", "sys/_types/_gid_t.h", "sys/_types/_dev_t.h"},
@@ -44,6 +46,7 @@ if ffi.os == "OSX" then
 		["netinet/udp_var.h"] = {"net/if.h", "netinet/ip_var.h", "netinet/udp.h"}, -- struct ipovly, struct udphdr
 	}
 	ffi.cdef "#define XP_NO_X_HEADERS"
+	ffi.cdef "#define _DNS_SD_LIBDISPATCH (0)"
 	ffi.cdef "#include <sys/types.h>"
 	ffi.cdef "#include <netinet/in.h>"
 	ffi.cdef "#include <stdio.h>"


### PR DESCRIPTION
- support some kind of functional macro definition correctly 
 - eg) like S_ISDIR
- support "__VA_ARGS__" and "..." in macro definition
- for gcc, able to caches output (include paths, predefined macros) so that ffiex can run without presence of installed gcc
- calling ffiex.init_cdef_cache() with presence of gcc, creates following files under ffiex/cache
 - version : output of 'gcc -v'
 - builtin_defs : output of 'echo | gcc -E -dM -' 
 - builtin_paths : output of 'echo | gcc -xc -v - 2>&1 | cat'
- currently cache feature is mainly focused on using with docker image building.